### PR TITLE
Update deprecated diagnostic call, switch <C-n> and <C-p>

### DIFF
--- a/fnl/magic/plugin/lspconfig.fnl
+++ b/fnl/magic/plugin/lspconfig.fnl
@@ -20,8 +20,8 @@
     (map :gi "lua vim.lsp.buf.implementation()")
     (map :K "lua vim.lsp.buf.hover()")
     (map :<c-k> "lua vim.lsp.buf.signature_help()")
-    (map :<c-n> "lua vim.lsp.diagnostic.goto_prev()")
-    (map :<c-p> "lua vim.lsp.diagnostic.goto_next()")
+    (map :<c-p> "lua vim.diagnostic.goto_prev()")
+    (map :<c-n> "lua vim.diagnostic.goto_next()")
 
     (map :<leader>lr "lua vim.lsp.buf.rename()")
     (map :<leader>lf "lua vim.lsp.buf.formatting()")))


### PR DESCRIPTION
`vim.lsp.diagnostic.goto_prev/next()` has been deprecated in favour of `vim.diagnostic.goto_prev/next()`.
Also, earlier `<C-p>` was mapped to "next", and `<C-n>` to "prev". I believe it makes more sense for it to be the other way around.